### PR TITLE
35-fix backend url for production

### DIFF
--- a/frontend/src/app/core/api.ts
+++ b/frontend/src/app/core/api.ts
@@ -8,7 +8,7 @@ import { ItemsApiResponse } from './item.model';
 })
 export class Api {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = 'http://localhost:3000/items';
+  private readonly apiUrl = 'https://tup-educativa.onrender.com';
 
   getItems(): Observable<ItemsApiResponse> {
     return this.http.get<ItemsApiResponse>(this.apiUrl);


### PR DESCRIPTION
Se modifico el archivo frontend/src/app/core/api.ts para reemplazar la URL de localhost por la URL pública definitiva del backend alojado en Render